### PR TITLE
Stijlen van de lijst op de homepagina

### DIFF
--- a/src/lib/Pages/Home/SiteOverview.svelte
+++ b/src/lib/Pages/Home/SiteOverview.svelte
@@ -1,13 +1,19 @@
 <script>
   import { IconLibrary, DonutChart, WarningSign } from '$lib';
   export let data = data;
+  console.log(data.sites[0].title)
 
   const filterUrlCheck = (url) => {
     const filterUrl = ["https://", "www."];
     let cleanedUrl = url;
+
     filterUrl.forEach((part) => {
       cleanedUrl = cleanedUrl.replace(part, "");
     });
+
+    if (cleanedUrl.length > 10) {
+      return cleanedUrl.substring(0, 15) + '...'
+    }
     return cleanedUrl;
   }; 
 </script>
@@ -21,7 +27,7 @@
         <h2>{title}</h2>
         <p>{filterUrlCheck(url)}</p>
       </section>
-        <WarningSign grade='fine'>
+        <WarningSign grade='good'>
           <p>toegankelijk</p>
         </WarningSign>
     </div>
@@ -51,6 +57,11 @@ ul {
     grid-template-columns: 0.2fr 0.5fr 0.3fr;
     justify-content: space-between ;
     gap: var(--average-gap);
+
+    @media (min-width: 900px) {
+      grid-template-columns: 0.2fr 1fr 0.3fr;
+    }
+
   }
 
   ul li div {
@@ -59,14 +70,17 @@ ul {
     justify-content: space-between;
   }
 
-  ul li div div {
-    background-color: var(--color-status-good);
-    border-radius: var(--section-border-radius);
-    border: solid 2px var(--color-status-good-border);
-    display: grid;
-    grid-template-columns: 10% 90%;
-    align-items: center;
-    align-content: center;
+  ul li div section p {
+    font-size: var(--font-size-small);
+  }
+
+  ul li div section h2 {
+    line-height: 1em;
+    font-size: var(--font-size-large);
+
+    @media (min-width: 900px) {
+      font-size: var(--font-size-medium);
+    }
   }
 
 </style>


### PR DESCRIPTION
Voor #189 heb ik feedback verwerkt van @Khdulkadir. Waarbij bepaalde dingen niet goed werden aangelijnd. Inmiddels heb ik meer geneste media queries ingevoegd en een script toegevoegd die bepaalde dingen inkort.

> * zie #189

# Wat heb je gedaan in deze pull-request?
* Ik heb de lijst van de homepagina iets mooier gemaakt en meer `@media` ingevoegd, zodat het wat netter aanlijnt in de lijst

## Screenshot van verandering
### voor
<img width="455" alt="image" src="https://github.com/user-attachments/assets/89c4a8f3-497f-49ba-ae12-18f509e3713b" />

### na
<img width="456" alt="image" src="https://github.com/user-attachments/assets/8a6585fe-b451-472f-a04c-5beb57b9060b" />


## opmerkingen
* ik heb een script gebruikt die de link onder de heading inkort, deze was namelijk soms zo lang. Ik vraag me sowieso af of dat niet anders moet misschien

# Wat moeten andere checken aan deze pull-request?
Welke onderdelen moeten worden gecheckt aan deze `pull-request`? Moet worden gekeken naar code, mappen of andere onderdelen?
* [ ] is de js duidelijk?
* [ ] is het goede code 
* [ ] Is het PE? 
* [ ] Is het accessibel?
* [ ] Is het goed responsive?


